### PR TITLE
Add syntactic sugar transactRaw to ConnectionIOOps

### DIFF
--- a/modules/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/modules/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -14,6 +14,8 @@ import doobie.hi.{connection as IHC}
 
 class ConnectionIOOps[A](ma: ConnectionIO[A]) {
   def transact[M[_]: MonadCancelThrow](xa: Transactor[M]): M[A] = xa.trans.apply(ma)
+
+  def transactRaw[M[_]: MonadCancelThrow](xa: Transactor[M]): M[A] = xa.rawTrans.apply(ma)
 }
 
 class OptionTConnectionIOOps[A](ma: OptionT[ConnectionIO, A]) {

--- a/modules/core/src/test/scala/doobie/util/ConnectionIOSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/ConnectionIOSuite.scala
@@ -24,10 +24,12 @@ class ConnectionIOSuite extends munit.CatsEffectSuite {
   test("Semigroup ConnectionIO") {
     val prg = Applicative[ConnectionIO].pure(List(1, 2, 3)) `combine` Applicative[ConnectionIO].pure(List(4, 5, 6))
     prg.transact(xa).assertEquals(List(1, 2, 3, 4, 5, 6))
+    prg.transactRaw(xa).assertEquals(List(1, 2, 3, 4, 5, 6))
   }
 
   test("Monoid ConnectionIO") {
     Monoid[ConnectionIO[List[Int]]].empty.transact(xa).assertEquals(Nil)
+    Monoid[ConnectionIO[List[Int]]].empty.transactRaw(xa).assertEquals(Nil)
   }
 
 }

--- a/modules/core/src/test/scala/doobie/util/ConnectionIOSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/ConnectionIOSuite.scala
@@ -24,11 +24,18 @@ class ConnectionIOSuite extends munit.CatsEffectSuite {
   test("Semigroup ConnectionIO") {
     val prg = Applicative[ConnectionIO].pure(List(1, 2, 3)) `combine` Applicative[ConnectionIO].pure(List(4, 5, 6))
     prg.transact(xa).assertEquals(List(1, 2, 3, 4, 5, 6))
+  }
+
+  test("Semigroup ConnectionIO raw") {
+    val prg = Applicative[ConnectionIO].pure(List(1, 2, 3)) `combine` Applicative[ConnectionIO].pure(List(4, 5, 6))
     prg.transactRaw(xa).assertEquals(List(1, 2, 3, 4, 5, 6))
   }
 
   test("Monoid ConnectionIO") {
     Monoid[ConnectionIO[List[Int]]].empty.transact(xa).assertEquals(Nil)
+  }
+
+  test("Monoid ConnectionIO raw") {
     Monoid[ConnectionIO[List[Int]]].empty.transactRaw(xa).assertEquals(Nil)
   }
 


### PR DESCRIPTION
`ConnectionIOOps` already has syntax for calling `.transact(xa)` on a query, which applies `xa.trans`, but there is no equivalent for `xa.rawTrans`.

`xa.rawTrans` is useful when one does not want to use the `Strategy`, namely when we want to keep the `autoCommit` setting of the underlying DB connection instead of having Doobie override it to `false`, which it does by default. In other words, [as the Doobie documentation puts it](https://typelevel.org/doobie/docs/14-Managing-Connections.html#about-transactors), "This can be useful in cases **where transactional handling is unsupported or undesired**".

Here, we add `transactRaw` as a new syntax in `ConnectionIOOps`, paralleling the existing `transact`.

See the discussion here:
- https://github.com/typelevel/doobie/issues/1244#issuecomment-2757961204

---

TBD:
- [ ] Do we also add the method to the others in the same file (`OptionTConnectionIOOps`, `EitherTConnectionIOOps`, `KleisliConnectionIOOps`) to keep their symmetry with `ConnectionIOOps`? But those classes don't have unit tests.